### PR TITLE
Extract runtime control helpers

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import os
-import time
 import traceback
 from pathlib import Path
 from threading import Lock
@@ -36,6 +35,17 @@ from src.resume_builder.resume_generator import ResumeGenerator
 from src.resume_builder.resume_manager import ResumeManager
 from src.resume_builder.style_manager import StyleManager
 from src.utils.browser_utils import create_playwright_browser, save_browser_session
+# Local runtime patch: keep fork-specific shutdown handling isolated to one module.
+from src.utils.runtime_control import (
+    BrowserClosedError,
+    GracefulShutdownRequested,
+    attach_browser_close_watchers,
+    countdown_before_restart,
+    register_shutdown_handlers,
+    run_with_runtime_guards,
+    runtime_controller,
+    sleep_with_shutdown,
+)
 from src.utils.utils import (
     get_first_pdf_file,
     load_yaml_file,
@@ -173,8 +183,13 @@ def start_keyboard_listener():
 async def check_pause():
     """Check if execution is paused and wait if needed"""
     global paused
+    # Local runtime patch: allow pause loops to exit promptly on shutdown requests.
+    if runtime_controller.is_shutdown_requested():
+        raise GracefulShutdownRequested("Shutdown requested")
     if paused:
         while paused:
+            if runtime_controller.is_shutdown_requested():
+                raise GracefulShutdownRequested("Shutdown requested")
             await asyncio.sleep(0.5)
 
 
@@ -186,13 +201,19 @@ async def create_and_run_bot(
 ):
     """Start LinkedIn bot (async)"""
     logger.info("Initializing LinkedIn bot...")
+    # Local runtime patch: coordinate cleanup with OS signal handlers.
+    runtime_controller.begin_run()
+    browser = context = page = None
 
     # Initialize browser Playwright based on configuration
     try:
         browser, context, page = await create_playwright_browser()
+        # Local runtime patch: detect manual browser closure and recover cleanly.
+        browser_closed = attach_browser_close_watchers(browser, context, page)
         logger.info("Playwright browser initialized successfully")
 
     except Exception as e:
+        runtime_controller.finish_run()
         logger.error(f"Browser initialization error: {e}")
         raise RuntimeError(f"Failed to initialize browser: {e}")
 
@@ -271,27 +292,35 @@ async def create_and_run_bot(
         bot.set_resume(resume_structured, resume_text, resume_text_anonymized)
         if not READY_MADE_RESUME.resolve().is_file():
             bot.set_resume_generator(resume_generator_manager)
-        await bot.start_apply()
+        # Local runtime patch: race bot execution against shutdown and browser-close events.
+        await run_with_runtime_guards(bot, browser_closed)
 
     finally:
         # Cleanup browser resources
         logger.info("Cleaning up browser resources...")
         try:
-            await save_browser_session(context)
-            # Close Playwright browser
-            await browser.close()
-            logger.info("Playwright browser closed")
+            if context is not None:
+                await save_browser_session(context)
+            if browser is not None:
+                await browser.close()
+                logger.info("Playwright browser closed")
 
         except Exception as e:
             logger.warning(f"Error during browser cleanup: {e}")
+        finally:
+            # Local runtime patch: release any pending shutdown handler waits.
+            runtime_controller.finish_run()
 
 
 def main() -> None:
     # Start keyboard listener for pause/resume functionality
+    # Local runtime patch: register graceful shutdown handlers once at startup.
+    register_shutdown_handlers()
     start_keyboard_listener()
 
     while True:
         should_exit = False
+        should_restart = False
         try:
             # create output folder if it doesn't exist
             data = Path("data")
@@ -316,12 +345,26 @@ def main() -> None:
             # Run LinkedIn bot (async)
             asyncio.run(create_and_run_bot(search_config, secrets, resume_text, resume_structured))
             logger.info("LinkedIn bot completed successfully")
+            if not RESTART_EVERY_DAY:
+                should_exit = True
 
         except ConfigError as ce:
             logger.error(f"Configuration error: {str(ce)}")
         except FileNotFoundError as fnf:
             tb_str = traceback.format_exc()
             logger.error(f"File not found: {str(fnf)}\n{tb_str}")
+        # Local runtime patch: custom runtime exceptions stay grouped here for easy rebasing.
+        except BrowserClosedError as bce:
+            logger.warning(str(bce))
+            should_restart = countdown_before_restart()
+            should_exit = not should_restart
+        except GracefulShutdownRequested:
+            logger.info("Graceful shutdown requested. Exiting after cleanup.")
+            should_exit = True
+        except KeyboardInterrupt:
+            runtime_controller.request_shutdown("keyboard interrupt")
+            logger.info("Interrupted by user. Exiting after cleanup.")
+            should_exit = True
         except RuntimeError as re:
             tb_str = traceback.format_exc()
             logger.error(f"Runtime error: {str(re)}\n{tb_str}")
@@ -330,10 +373,16 @@ def main() -> None:
             logger.error(f"Unknown error: {str(e)}\n{tb_str}")
         finally:
             logger.info("Program completed")
-            # Wait 1 hour total before next run
-            if RESTART_EVERY_DAY:
+            if should_restart:
+                logger.info("Restarting after browser closure")
+            elif should_exit:
+                logger.info("Exiting program")
+            elif RESTART_EVERY_DAY:
                 logger.info("Waiting 1 hour before next run")
-                time.sleep(3600)
+                # Local runtime patch: make the daily wait interruptible.
+                if not asyncio.run(sleep_with_shutdown(3600)):
+                    logger.info("Shutdown requested during wait interval")
+                    should_exit = True
             else:
                 logger.info("Exiting program")
                 should_exit = True

--- a/src/utils/runtime_control.py
+++ b/src/utils/runtime_control.py
@@ -1,0 +1,178 @@
+import asyncio
+import ctypes
+import os
+import signal
+import time
+from threading import Event
+from typing import Any
+
+from config.logger_config import logger
+
+_shutdown_handlers_registered = False
+_windows_console_handler = None
+
+
+class BrowserClosedError(RuntimeError):
+    """Raised when the browser window is closed during a run."""
+
+
+class GracefulShutdownRequested(RuntimeError):
+    """Raised when the application should stop after cleanup."""
+
+
+class RuntimeController:
+    """Coordinates shutdown and browser-close reactions across sync/async boundaries."""
+
+    def __init__(self) -> None:
+        self.shutdown_requested = Event()
+        self.cleanup_complete = Event()
+        self.cleanup_complete.set()
+
+    def request_shutdown(self, source: str) -> None:
+        if not self.shutdown_requested.is_set():
+            logger.warning(f"Shutdown requested via {source}. Finishing current cleanup.")
+        self.shutdown_requested.set()
+
+    def is_shutdown_requested(self) -> bool:
+        return self.shutdown_requested.is_set()
+
+    def begin_run(self) -> None:
+        self.cleanup_complete.clear()
+
+    def finish_run(self) -> None:
+        self.cleanup_complete.set()
+
+    def wait_for_cleanup(self, timeout: float = 15.0) -> bool:
+        return self.cleanup_complete.wait(timeout)
+
+
+runtime_controller = RuntimeController()
+
+
+def _handle_shutdown_signal(signum, _frame) -> None:
+    """Convert OS signals into a graceful shutdown request."""
+    try:
+        signal_name = signal.Signals(signum).name
+    except ValueError:
+        signal_name = str(signum)
+    runtime_controller.request_shutdown(f"signal {signal_name}")
+
+
+def register_shutdown_handlers() -> None:
+    """Register SIGINT/SIGTERM and Windows console-close handlers once."""
+    global _shutdown_handlers_registered, _windows_console_handler
+    if _shutdown_handlers_registered:
+        return
+
+    signal.signal(signal.SIGINT, _handle_shutdown_signal)
+    if hasattr(signal, "SIGTERM"):
+        signal.signal(signal.SIGTERM, _handle_shutdown_signal)
+
+    if os.name == "nt":
+        handler_type = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.c_uint)
+        event_names = {
+            0: "CTRL_C_EVENT",
+            1: "CTRL_BREAK_EVENT",
+            2: "CTRL_CLOSE_EVENT",
+            5: "CTRL_LOGOFF_EVENT",
+            6: "CTRL_SHUTDOWN_EVENT",
+        }
+
+        def console_handler(ctrl_type: int) -> bool:
+            runtime_controller.request_shutdown(
+                f"console event {event_names.get(ctrl_type, ctrl_type)}"
+            )
+            runtime_controller.wait_for_cleanup(timeout=15.0)
+            return True
+
+        _windows_console_handler = handler_type(console_handler)
+        ctypes.windll.kernel32.SetConsoleCtrlHandler(_windows_console_handler, True)
+
+    _shutdown_handlers_registered = True
+
+
+def attach_browser_close_watchers(browser: Any, context: Any, page: Any) -> asyncio.Event:
+    """Return an event that fires when the browser/page/context is closed."""
+    browser_closed = asyncio.Event()
+
+    def mark_closed(target_name: str) -> None:
+        if not browser_closed.is_set():
+            logger.warning(
+                f"{target_name} was closed. Press Ctrl+C to stop, or the bot will reopen the browser shortly."
+            )
+            browser_closed.set()
+
+    browser.on("disconnected", lambda: mark_closed("Browser"))
+    context.on("close", lambda: mark_closed("Browser context"))
+    page.on("close", lambda: mark_closed("Browser page"))
+    return browser_closed
+
+
+async def _wait_for_shutdown_request() -> str:
+    await asyncio.to_thread(runtime_controller.shutdown_requested.wait)
+    return "shutdown"
+
+
+async def _wait_for_browser_close(browser_closed: asyncio.Event) -> str:
+    await browser_closed.wait()
+    return "browser_closed"
+
+
+async def _cancel_task(task: asyncio.Task | None) -> None:
+    if task is None or task.done():
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+async def run_with_runtime_guards(bot: Any, browser_closed: asyncio.Event):
+    """Race the bot against runtime control events."""
+    apply_task = asyncio.create_task(bot.start_apply())
+    browser_task = asyncio.create_task(_wait_for_browser_close(browser_closed))
+    shutdown_task = asyncio.create_task(_wait_for_shutdown_request())
+
+    try:
+        done, _pending = await asyncio.wait(
+            {apply_task, browser_task, shutdown_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        if apply_task in done:
+            return await apply_task
+
+        if browser_task in done:
+            await _cancel_task(apply_task)
+            raise BrowserClosedError("Browser window closed by user")
+
+        if shutdown_task in done:
+            await _cancel_task(apply_task)
+            raise GracefulShutdownRequested("Shutdown requested")
+    finally:
+        await _cancel_task(browser_task)
+        await _cancel_task(shutdown_task)
+
+
+async def sleep_with_shutdown(seconds: int) -> bool:
+    """Sleep in short chunks so shutdown requests are honored quickly."""
+    for _ in range(seconds):
+        if runtime_controller.is_shutdown_requested():
+            return False
+        await asyncio.sleep(1)
+    return not runtime_controller.is_shutdown_requested()
+
+
+def countdown_before_restart(seconds: int = 5) -> bool:
+    """Give the user a short window to cancel restart after browser closure."""
+    logger.warning(
+        "I can reopen the browser and continue. Press Ctrl+C now to stop applications."
+    )
+    for remaining in range(seconds, 0, -1):
+        if runtime_controller.is_shutdown_requested():
+            logger.info("Restart cancelled by shutdown request")
+            return False
+        logger.warning(f"Reopening browser in {remaining}...")
+        time.sleep(1)
+    return not runtime_controller.is_shutdown_requested()


### PR DESCRIPTION
## Summary
- extract graceful shutdown and browser-close handling into a dedicated runtime control module
- let the main loop stop cleanly on Ctrl+C, console close events, and browser closure
- make the daily restart wait interruptible instead of blocking in time.sleep

## Testing
- python -m compileall main.py src/utils/runtime_control.py
