### PR TITLE
Add submitted resume path tracking and UI display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,7 @@ browser_session/*
 browser_session_my/*
 browser_session_work/*
 config/app_config*.py
-config/linkedin_connection_searcher_config.yaml
-config/search_config*.yaml
+config/*.yaml
 data/cover_letters/*
 data/output/*
 data/resumes/*

--- a/src/dashboard/data_service.py
+++ b/src/dashboard/data_service.py
@@ -79,9 +79,14 @@ def _flatten_company_jobs(
                     "skills": job.get("skills"),
                     "llm_time_seconds": job.get("llm_time_seconds", 0.0),
                     "executed_at": job.get("executed_at"),
+                    "submitted_resume_path": job.get("submitted_resume_path"),
                 }
             )
     return rows
+
+
+def _job_url_key(url: str | None) -> str:
+    return (url or "").rstrip("/")
 
 
 def _load_jobs_board() -> List[Dict[str, Any]]:
@@ -121,6 +126,7 @@ def _load_jobs_board() -> List[Dict[str, Any]]:
                 "skills": None,
                 "llm_time_seconds": current_job.get("llm_time_seconds", 0.0),
                 "executed_at": current_job.get("executed_at") or snapshot.get("last_event_at"),
+                "submitted_resume_path": current_job.get("submitted_resume_path"),
             },
         )
 
@@ -166,6 +172,7 @@ def _build_run_jobs(run_id: str) -> List[Dict[str, Any]]:
                 "skills": None,
                 "llm_time_seconds": 0.0,
                 "executed_at": event.get("timestamp"),
+                "submitted_resume_path": payload.get("submitted_resume_path"),
                 "stage": payload.get("stage"),
                 "last_message": event.get("message"),
                 "updated_at": event.get("timestamp"),
@@ -178,6 +185,9 @@ def _build_run_jobs(run_id: str) -> List[Dict[str, Any]]:
         job["stage"] = payload.get("stage") or job.get("stage")
         job["last_message"] = event.get("message") or job.get("last_message")
         job["updated_at"] = event.get("timestamp") or job.get("updated_at")
+        job["submitted_resume_path"] = payload.get("submitted_resume_path") or job.get(
+            "submitted_resume_path"
+        )
 
         event_type = event.get("type")
         if event_type == "llm_call_completed":
@@ -218,7 +228,33 @@ def _build_run_jobs(run_id: str) -> List[Dict[str, Any]]:
                 job["status"] = "failed"
                 job["skip_reason"] = payload.get("reason") or job.get("skip_reason", "")
 
-    rows = list(jobs.values())
+    saved_jobs_by_url = {
+        _job_url_key(job.get("url")): job
+        for job in (
+            _flatten_company_jobs(_read_yaml(SUCCESS_FILE, {}), "applied")
+            + _flatten_company_jobs(_read_yaml(SKIPPED_FILE, {}), "skipped")
+            + _flatten_company_jobs(_read_yaml(FAILED_FILE, {}), "failed")
+        )
+        if job.get("url")
+    }
+
+    rows = []
+    for job in jobs.values():
+        saved_job = saved_jobs_by_url.get(_job_url_key(job.get("url")))
+        if saved_job:
+            for field in ("company_name", "job_title", "skip_reason", "interest_reason"):
+                job[field] = job.get(field) or saved_job.get(field)
+            if job.get("interest_score") in (None, 0):
+                job["interest_score"] = saved_job.get("interest_score")
+            if not job.get("skills"):
+                job["skills"] = saved_job.get("skills")
+            if not job.get("llm_time_seconds"):
+                job["llm_time_seconds"] = saved_job.get("llm_time_seconds", 0.0)
+            if not job.get("submitted_resume_path"):
+                job["submitted_resume_path"] = saved_job.get("submitted_resume_path")
+            job["executed_at"] = job.get("executed_at") or saved_job.get("executed_at")
+        rows.append(job)
+
     rows.sort(
         key=lambda job: (
             job.get("status") != "in_progress",

--- a/src/dashboard/static/app.js
+++ b/src/dashboard/static/app.js
@@ -42,6 +42,11 @@ function formatDateTime(value) {
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }
 
+function formatResumePath(path) {
+  if (!path) return "-";
+  return path.split(/[\\/]/).pop() || path;
+}
+
 function currentRunPath(runId) {
   return runId ? `/runs/${encodeURIComponent(runId)}` : "/";
 }
@@ -139,6 +144,7 @@ function renderJobs(jobs) {
         <td><a href="${job.url || "#"}" target="_blank" rel="noreferrer">${job.job_title || "Unknown job"}</a></td>
         <td>${job.company_name || "-"}</td>
         <td>${job.interest_score ?? "-"}</td>
+        <td title="${(job.submitted_resume_path || "").replaceAll('"', '&quot;')}">${formatResumePath(job.submitted_resume_path)}</td>
         <td title="${(job.interest_reason || job.skip_reason || "").replaceAll('"', '&quot;')}">${job.skip_reason || job.interest_reason || "-"}</td>
       </tr>
     `)
@@ -176,6 +182,7 @@ function renderJobDetails(job) {
       <div><dt>Interest Score</dt><dd>${job.interest_score ?? "-"}</dd></div>
       <div><dt>Skip Reason</dt><dd>${job.skip_reason || "-"}</dd></div>
       <div><dt>Interest Reason</dt><dd>${job.interest_reason || "-"}</dd></div>
+      <div><dt>Submitted Resume</dt><dd>${job.submitted_resume_path || "-"}</dd></div>
       <div><dt>Skills</dt><dd>${Array.isArray(job.skills) ? job.skills.join(", ") : job.skills || "-"}</dd></div>
     </dl>
   `;

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -99,6 +99,7 @@
                 <th>Title</th>
                 <th>Company</th>
                 <th>Score</th>
+                <th>Resume</th>
                 <th>Reason</th>
               </tr>
             </thead>

--- a/src/job_manager/easy_applier.py
+++ b/src/job_manager/easy_applier.py
@@ -51,7 +51,7 @@ class BaseEasyApplier(ABC):
     async def _find_and_handle_date_question(self, section: Any) -> bool:
         return False
 
-    async def _create_and_upload_resume(self, element: Any, job: Job) -> None:
+    async def _create_and_upload_resume(self, element: Any, job: Job) -> str:
         try:
             os.makedirs(self.generated_resume_dir, exist_ok=True)
         except Exception as e:
@@ -106,9 +106,12 @@ class BaseEasyApplier(ABC):
             )
 
         try:
-            await element.set_input_files(os.path.abspath(file_path_pdf))
+            abs_path = os.path.abspath(file_path_pdf)
+            await element.set_input_files(abs_path)
+            self.submitted_resume_path = abs_path
             await async_pause(1, 2)
             logger.debug(f"Resume created and uploaded successfully: {file_path_pdf}")
+            return abs_path
         except Exception:
             tb_str = traceback.format_exc()
             logger.error(f"Resume upload failed: {tb_str}")

--- a/src/job_manager/job_manager.py
+++ b/src/job_manager/job_manager.py
@@ -49,7 +49,8 @@ class BaseJobManager(ABC):
         logger.info("Setting job manager parameters")
         self.max_applies_num = MAX_APPLIES_NUM
         self.apply_once_at_company = parameters.get("apply_once_at_company", True)
-        self.job_blacklist = [sanitize_text(j) for j in parameters.get("company_blacklist", [])]
+        company_blacklist = parameters.get("company_blacklist") or []
+        self.job_blacklist = [sanitize_text(j) for j in company_blacklist]
         self.success_companies = self._load_companies_from_yaml("success.yaml")
         self.skipped_companies = self._load_companies_from_yaml("skipped.yaml")
         self.failed_companies = self._load_companies_from_yaml("failed.yaml")
@@ -152,6 +153,7 @@ class BaseJobManager(ABC):
                     else 0.0
                 ),
                 executed_at=datetime.now().isoformat(timespec="seconds"),
+                submitted_resume_path=evaluation.get("submitted_resume_path"),
             )
         except Exception as e:
             logger.warning(f"Error in saving job info: {e}")
@@ -437,6 +439,7 @@ class BaseJobManager(ABC):
             job_title=job.job_title,
             company_name=job.company_name,
             url=job.url,
+            submitted_resume_path=(evaluation or {}).get("submitted_resume_path"),
         )
         self.applies_num += 1
         if result != "Limit" and COLLECT_INFO_MODE is False:

--- a/src/job_manager/linkedin/easy_applier_linkedin.py
+++ b/src/job_manager/linkedin/easy_applier_linkedin.py
@@ -49,6 +49,7 @@ class LinkedInEasyApplier(BaseEasyApplier):
         self.ready_made_resume_path = get_ready_made_resume()
         self.all_questions = self._load_questions()
         self.current_job = None
+        self.submitted_resume_path = None
         self.test_mode = test_mode
         self.previous_question_texts = []
         logger.info("LinkedInEasyApplier initialized successfully")
@@ -600,6 +601,7 @@ class LinkedInEasyApplier(BaseEasyApplier):
                     if self.ready_made_resume_path is not None:
                         abs_path = os.path.abspath(str(self.ready_made_resume_path))
                         await upload_element.set_input_files(abs_path)
+                        self.submitted_resume_path = abs_path
                         logger.info(f"Resume uploaded from path: {self.ready_made_resume_path}")
                         await async_pause(2, 3)
                     else:

--- a/src/job_manager/linkedin/job_manager_linkedin.py
+++ b/src/job_manager/linkedin/job_manager_linkedin.py
@@ -52,6 +52,7 @@ class LinkedInJobManager(BaseJobManager):
         self.llm_answerer_component = None
         self.llm_agent_component = None
         self.resume_generator_manager = None
+        self.submitted_resume_path = None
         self.pause_checker = None
         self.jobs_no_info = (
             []
@@ -237,6 +238,7 @@ class LinkedInJobManager(BaseJobManager):
             company_name = job.company_name
             company_job_title = job.job_title
             logger.info(f"Found a vacancy {company_job_title}")
+            self.submitted_resume_path = None
             # if the vacancy has not been seen yet and the company is not in the blacklist
             # - start the process of applying to the vacancy
             if not job.is_valid_for_application():
@@ -321,6 +323,8 @@ class LinkedInJobManager(BaseJobManager):
                         apply_result = await self.easy_apply(job)
                 else:
                     apply_result = await self.easy_apply(job)
+                if self.submitted_resume_path:
+                    evaluation["submitted_resume_path"] = self.submitted_resume_path
                 # if the vacancy is skipped for the reason of missing information, add it to the list of vacancies,
                 # information about which will then be sent to the client
                 result, reason = apply_result
@@ -359,7 +363,9 @@ class LinkedInJobManager(BaseJobManager):
             TEST_MODE,
         )
         easy_applier_component.set_page(self.page)
-        return await easy_applier_component.apply_to_job(job)
+        apply_result = await easy_applier_component.apply_to_job(job)
+        self.submitted_resume_path = easy_applier_component.submitted_resume_path
+        return apply_result
 
     async def _scroll_to_load_jobs(self):
         """Scroll the job results container to load all job listings (async)"""

--- a/src/job_manager/search_customizer.py
+++ b/src/job_manager/search_customizer.py
@@ -37,11 +37,11 @@ class BaseSearchCustomizer(ABC):
         self.experience_level = parameters.get("experience_level", {})
         self.job_types = parameters.get("job_types", {})
         self.date_posted = parameters.get("date", {})
-        self.locations = parameters.get("locations", [])
+        self.locations = parameters.get("locations") or []
         self.apply_once_at_company = parameters.get("apply_once_at_company", True)
-        self.company_blacklist = parameters.get("company_blacklist", [])
-        self.title_blacklist = parameters.get("title_blacklist", [])
-        self.location_blacklist = parameters.get("location_blacklist", [])
+        self.company_blacklist = parameters.get("company_blacklist") or []
+        self.title_blacklist = parameters.get("title_blacklist") or []
+        self.location_blacklist = parameters.get("location_blacklist") or []
         logger.info(f"{self.__class__.__name__} parameters successfully set")
 
     def is_job_blacklisted(self, job_title: str, company_name: str, job_location: str) -> bool:

--- a/src/pydantic_models/config_models.py
+++ b/src/pydantic_models/config_models.py
@@ -77,6 +77,19 @@ class SearchConfig(BaseModel):
     title_blacklist: Optional[List[str]] = []
     location_blacklist: Optional[List[str]] = []
 
+    @field_validator(
+        "locations",
+        "company_blacklist",
+        "title_blacklist",
+        "location_blacklist",
+        mode="before",
+    )
+    @classmethod
+    def none_list_fields_default_to_empty(cls, value):
+        if value is None:
+            return []
+        return value
+
 
 class ConnectionSearcherConfig(BaseModel):
     main_search_words: List[str] = [

--- a/src/pydantic_models/job_models.py
+++ b/src/pydantic_models/job_models.py
@@ -249,6 +249,9 @@ class JobInfo(BaseModel):
     executed_at: Optional[str] = Field(
         default=None, description="When the job was processed by the bot"
     )
+    submitted_resume_path: Optional[str] = Field(
+        default=None, description="Path of the resume file submitted with the application"
+    )
 
     @field_validator("interest_score", mode="before")
     @classmethod

--- a/tests/test_dashboard_data_service.py
+++ b/tests/test_dashboard_data_service.py
@@ -301,6 +301,7 @@ def test_get_run_jobs_builds_status_from_events(monkeypatch):
                     "result": "Success",
                     "reason": "",
                     "llm_time_seconds": 1.5,
+                    "submitted_resume_path": "/tmp/resumes/cto.pdf",
                 },
             },
             {
@@ -336,9 +337,65 @@ def test_get_run_jobs_builds_status_from_events(monkeypatch):
     assert len(jobs) == 2
     assert any(job["status"] == "applied" and job["interest_score"] == 92 for job in jobs)
     assert any(
+        job["status"] == "applied"
+        and job["submitted_resume_path"] == "/tmp/resumes/cto.pdf"
+        for job in jobs
+    )
+    assert any(
         job["status"] == "skipped" and job["skip_reason"] == "Vacancy is not interesting"
         for job in jobs
     )
+
+
+def test_get_run_jobs_enriches_missing_fields_from_saved_outputs(monkeypatch, tmp_path):
+    output_dir = tmp_path / "data" / "output"
+    _write_yaml(
+        output_dir / "success.yaml",
+        {
+            "1inch": [
+                {
+                    "company_name": "1inch",
+                    "job_title": "Chief Product Officer",
+                    "url": "https://www.linkedin.com/jobs/view/4401460753/",
+                    "interest_score": 75,
+                    "interest_reason": "Strong fintech and Web3 alignment",
+                    "skills": ["product strategy", "web3"],
+                    "llm_time_seconds": 28.037,
+                }
+            ]
+        },
+    )
+    _write_yaml(output_dir / "skipped.yaml", {})
+    _write_yaml(output_dir / "failed.yaml", {})
+
+    monkeypatch.setattr(data_service, "SUCCESS_FILE", output_dir / "success.yaml")
+    monkeypatch.setattr(data_service, "SKIPPED_FILE", output_dir / "skipped.yaml")
+    monkeypatch.setattr(data_service, "FAILED_FILE", output_dir / "failed.yaml")
+    monkeypatch.setattr(
+        data_service,
+        "read_events_for_run",
+        lambda run_id, limit=5000: [
+            {
+                "run_id": run_id,
+                "type": "job_result",
+                "message": "Job finished with status Success",
+                "timestamp": "2026-04-28T11:23:12",
+                "payload": {
+                    "job_title": "Chief Product Officer",
+                    "company_name": "1inch",
+                    "url": "https://www.linkedin.com/jobs/view/4401460753",
+                    "result": "Success",
+                },
+            }
+        ][:limit],
+    )
+
+    jobs = data_service.get_run_jobs("run-1")
+
+    assert jobs[0]["interest_score"] == 75
+    assert jobs[0]["interest_reason"] == "Strong fintech and Web3 alignment"
+    assert jobs[0]["skills"] == ["product strategy", "web3"]
+    assert jobs[0]["llm_time_seconds"] == 28.037
 
 
 def test_get_jobs_includes_executed_at_from_saved_outputs(monkeypatch, tmp_path):
@@ -352,6 +409,7 @@ def test_get_jobs_includes_executed_at_from_saved_outputs(monkeypatch, tmp_path)
                     "job_title": "CTO",
                     "url": "https://linkedin.com/jobs/view/1",
                     "executed_at": "2026-04-15T10:02:00",
+                    "submitted_resume_path": "/tmp/resumes/cto.pdf",
                 }
             ]
         },
@@ -369,6 +427,7 @@ def test_get_jobs_includes_executed_at_from_saved_outputs(monkeypatch, tmp_path)
     jobs = data_service.get_jobs()
 
     assert jobs[0]["executed_at"] == "2026-04-15T10:02:00"
+    assert jobs[0]["submitted_resume_path"] == "/tmp/resumes/cto.pdf"
 
 
 def test_get_run_detail_combines_run_jobs_and_events(monkeypatch):

--- a/tests/test_easy_applier.py
+++ b/tests/test_easy_applier.py
@@ -248,6 +248,7 @@ class TestCreateAndUploadResume:
         mock_element.set_input_files.assert_called_once()
         call_arg = mock_element.set_input_files.call_args[0][0]
         assert "CV_TestCorp_Engineer.pdf" in call_arg
+        assert applier.submitted_resume_path == call_arg
 
     @pytest.mark.asyncio
     async def test_raises_when_file_exceeds_size_limit(self, applier, tmp_path):

--- a/tests/test_easy_applier_linkedin.py
+++ b/tests/test_easy_applier_linkedin.py
@@ -1,5 +1,6 @@
 """Tests for src/job_manager/linkedin/easy_applier_linkedin.py"""
 
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -332,6 +333,46 @@ class TestUploadFields:
 
         applier._create_and_upload_resume.assert_called_once_with(upload_element, job)
         upload_element.set_input_files.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_records_ready_made_resume_path_when_uploaded(self, applier, tmp_path):
+        ready_made_resume = tmp_path / "existing.pdf"
+        ready_made_resume.write_bytes(b"existing")
+        applier.ready_made_resume_path = ready_made_resume
+        applier.resume_generator_manager = None
+
+        upload_element = AsyncMock()
+        upload_element.get_attribute = AsyncMock(return_value="resume-upload")
+        upload_element.evaluate = AsyncMock()
+        upload_element.set_input_files = AsyncMock()
+
+        parent = AsyncMock()
+        parent.text_content = AsyncMock(return_value="Resume")
+        upload_element.locator = MagicMock(return_value=MagicMock(first=parent))
+
+        element = MagicMock()
+        upload_locator = MagicMock()
+        upload_locator.all = AsyncMock(return_value=[upload_element])
+        element.locator = MagicMock(return_value=upload_locator)
+
+        job = Job(job_title="Engineer", company_name="Tech")
+
+        with (
+            patch(
+                "src.job_manager.linkedin.easy_applier_linkedin.find_element_safely",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "src.job_manager.linkedin.easy_applier_linkedin.async_pause",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await applier._handle_upload_fields(element, job, set())
+
+        expected_path = os.path.abspath(str(ready_made_resume.resolve()))
+        upload_element.set_input_files.assert_called_once_with(expected_path)
+        assert applier.submitted_resume_path == expected_path
 
 
 class TestDeduplicateQuestionText:

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -164,6 +164,16 @@ class TestSetParameters:
             assert "evil corp" in job_applier.job_blacklist
             assert job_applier.applies_num == 0
 
+    def test_set_parameters_treats_none_company_blacklist_as_empty(self, job_applier):
+        with (
+            patch.object(job_applier, "_load_companies_from_yaml", return_value={}),
+            patch.object(job_applier, "_load_data_from_yaml", return_value=[]),
+            patch.object(job_applier, "_load_cache", return_value=JobManagerCache()),
+        ):
+            job_applier.set_parameters({"company_blacklist": None})
+
+        assert job_applier.job_blacklist == []
+
 
 class TestCacheManagement:
     """Test cache loading and writing"""
@@ -487,6 +497,7 @@ class TestCompanyManagement:
                     "interest_score": 42,
                     "interest_reason": "Mismatch with role target",
                     "skills": ["Python", "Leadership"],
+                    "submitted_resume_path": "/tmp/resume.pdf",
                 },
             )
 
@@ -494,6 +505,7 @@ class TestCompanyManagement:
             assert saved_job["interest_score"] == 42
             assert saved_job["interest_reason"] == "Mismatch with role target"
             assert saved_job["skills"] == ["Python", "Leadership"]
+            assert saved_job["submitted_resume_path"] == "/tmp/resume.pdf"
 
     def test_save_company_skip_does_not_duplicate_existing_entry(self, job_applier):
         """Test duplicate skipped vacancies are not appended again"""

--- a/tests/test_job_manager_linkedin.py
+++ b/tests/test_job_manager_linkedin.py
@@ -758,6 +758,7 @@ class TestEasyApply:
     async def test_delegates_to_linkedin_easy_applier(self, manager, test_job):
         mock_applier = AsyncMock()
         mock_applier.apply_to_job = AsyncMock(return_value=("Success", ""))
+        mock_applier.submitted_resume_path = "/tmp/resumes/generated.pdf"
 
         with patch(
             "src.job_manager.linkedin.job_manager_linkedin.LinkedInEasyApplier",
@@ -767,11 +768,13 @@ class TestEasyApply:
 
         assert result == ("Success", "")
         mock_applier.apply_to_job.assert_called_once_with(test_job)
+        assert manager.submitted_resume_path == "/tmp/resumes/generated.pdf"
 
     @pytest.mark.asyncio
     async def test_sets_page_on_applier(self, manager, test_job):
         mock_applier = AsyncMock()
         mock_applier.apply_to_job = AsyncMock(return_value=("Skip", ""))
+        mock_applier.submitted_resume_path = None
 
         with patch(
             "src.job_manager.linkedin.job_manager_linkedin.LinkedInEasyApplier",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,6 +46,24 @@ class TestConfigValidator:
             assert "experience_level" in result
             assert "job_types" in result
 
+    def test_validate_search_config_defaults_empty_blacklists(self, tmp_path):
+        config_file = tmp_path / "search_config.yaml"
+        config_data = {
+            "positions": ["Software Engineer"],
+            "locations": None,
+            "company_blacklist": None,
+            "title_blacklist": None,
+            "location_blacklist": None,
+        }
+
+        with patch("main.load_yaml_file", return_value=config_data):
+            result = ConfigValidator().validate_search_config(config_file)
+
+        assert result["locations"] == []
+        assert result["company_blacklist"] == []
+        assert result["title_blacklist"] == []
+        assert result["location_blacklist"] == []
+
     def test_validate_search_config_missing_required_fields(self, tmp_path):
         """Test validation fails with missing required fields"""
         config_file = tmp_path / "invalid_config.yaml"

--- a/tests/test_search_customizer.py
+++ b/tests/test_search_customizer.py
@@ -73,6 +73,22 @@ class TestSetAdvancedSearchParams:
         assert customizer.apply_once_at_company is True
         assert customizer.company_blacklist == []
 
+    def test_none_list_params_default_to_empty_lists(self, customizer):
+        customizer.set_advanced_search_params(
+            {
+                "positions": ["Engineer"],
+                "locations": None,
+                "company_blacklist": None,
+                "title_blacklist": None,
+                "location_blacklist": None,
+            }
+        )
+
+        assert customizer.locations == []
+        assert customizer.company_blacklist == []
+        assert customizer.title_blacklist == []
+        assert customizer.location_blacklist == []
+
 
 class TestIsJobBlacklisted:
     def test_title_blacklisted(self, customizer):

--- a/tests/test_search_customizer_linkedin.py
+++ b/tests/test_search_customizer_linkedin.py
@@ -438,6 +438,7 @@ class TestSetSearchParams:
     @pytest.mark.asyncio
     async def test_navigates_to_linkedin_jobs(self, customizer, mock_page):
         with (
+            patch(f"{MODULE}.LINKEDIN_RECOMMENDED_JOBS_MODE", False),
             patch(f"{MODULE}.async_pause"),
             patch.object(customizer, "_set_basic_search_terms", new_callable=AsyncMock),
             patch.object(
@@ -476,6 +477,7 @@ class TestSetSearchParams:
     @pytest.mark.asyncio
     async def test_calls_all_filter_setters_when_filters_open(self, customizer):
         with (
+            patch(f"{MODULE}.LINKEDIN_RECOMMENDED_JOBS_MODE", False),
             patch(f"{MODULE}.async_pause"),
             patch.object(customizer, "_set_basic_search_terms", new_callable=AsyncMock),
             patch.object(
@@ -507,6 +509,7 @@ class TestSetSearchParams:
     @pytest.mark.asyncio
     async def test_skips_filter_setters_when_filters_not_open(self, customizer):
         with (
+            patch(f"{MODULE}.LINKEDIN_RECOMMENDED_JOBS_MODE", False),
             patch(f"{MODULE}.async_pause"),
             patch.object(customizer, "_set_basic_search_terms", new_callable=AsyncMock),
             patch.object(


### PR DESCRIPTION
### Description of Changes

- Introduced the `submitted_resume_path` property to track and log the resume path associated with job applications.
- Integrated storage of `submitted_resume_path` in evaluation metadata to improve data traceability.
- Updated the dashboard UI to display `submitted_resume_path` alongside job details, with added formatting logic for file paths.
- Enhanced application workflows to ensure correct propagation and persistence of the new property.
- Refactored YAML blacklist handling to default empty fields to empty lists for better stability.
- Added and updated tests to validate the end-to-end functionality of the feature.

### Checklist

- [ ] Unit tests updated or added to cover changes
- [ ] Documentation updated (if applicable)
- [ ] All code changes adhere to the project's style guide