### PR TITLE
- Updated `save_yaml_file` to perform atomic writes with temporary file handling and directory flushing for data integrity. - Enhanced error handling and cleanup for temporary files in `save_yaml_file`. - Added `test_save_yaml_file_flushes_file_and_directory` to validate flushing behavior and temporary file cleanup.

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -56,11 +56,31 @@ def load_app_config() -> dict:
 
 
 def save_yaml_file(yaml_path: Path, data: dict, sort_keys: bool = True) -> None:
-    """Load settings from YAML configuration file"""
-    with open(yaml_path, "w", encoding="UTF-8") as stream:
-        yaml.safe_dump(
-            data, stream, allow_unicode=True, default_flow_style=False, sort_keys=sort_keys
-        )
+    """Save YAML data atomically and flush it to disk."""
+    yaml_path = Path(yaml_path)
+    yaml_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = yaml_path.with_name(
+        f".{yaml_path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+    )
+    try:
+        with open(tmp_path, "w", encoding="UTF-8") as stream:
+            yaml.safe_dump(
+                data, stream, allow_unicode=True, default_flow_style=False, sort_keys=sort_keys
+            )
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp_path, yaml_path)
+        try:
+            dir_fd = os.open(yaml_path.parent, os.O_DIRECTORY)
+        except OSError:
+            return
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
 
 
 def append_yaml_file(yaml_path: Path, data: dict) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,6 +112,17 @@ class TestSaveYamlFile:
         assert loaded_data == new_data
         assert loaded_data != initial_data
 
+    @patch("src.utils.utils.os.fsync")
+    def test_save_yaml_file_flushes_file_and_directory(self, mock_fsync, tmp_path):
+        """Test YAML saves are flushed so per-job output survives abrupt shutdowns"""
+        yaml_file = tmp_path / "output.yaml"
+
+        save_yaml_file(yaml_file, {"status": "saved"})
+
+        assert yaml_file.exists()
+        assert mock_fsync.call_count >= 2
+        assert list(tmp_path.glob("*.tmp")) == []
+
 
 class TestPause:
     """Tests for pause function"""


### PR DESCRIPTION
The app already saves each job result through _handle_apply_result() and _save_company(). The risk was that a force shutdown could interrupt or leave buffered YAML writes. Now each save is much more resilient against abrupt app/dashboard shutdowns.