### PR TITLE
feat: Add NVIDIA NIM, Groq, and Cerebras as LLM providers

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -114,6 +114,45 @@ PRICE_DICT: dict[str, dict[str, float]] = {
         "input_cost_per_token": 0.325 / 1_000_000,
         "output_cost_per_token": 1.30 / 1_000_000,
     },
+    # NVIDIA NIM
+    "meta/llama-3.3-70b-instruct": {
+        "input_cost_per_token": 0.27 / 1_000_000,
+        "output_cost_per_token": 0.85 / 1_000_000,
+    },
+    "meta/llama-3.1-405b-instruct": {
+        "input_cost_per_token": 1.00 / 1_000_000,
+        "output_cost_per_token": 3.00 / 1_000_000,
+    },
+    "nvidia/llama-3.1-nemotron-70b-instruct": {
+        "input_cost_per_token": 0.27 / 1_000_000,
+        "output_cost_per_token": 0.85 / 1_000_000,
+    },
+    # Groq
+    "llama-3.3-70b-versatile": {
+        "input_cost_per_token": 0.59 / 1_000_000,
+        "output_cost_per_token": 0.79 / 1_000_000,
+    },
+    "llama-3.1-8b-instant": {
+        "input_cost_per_token": 0.05 / 1_000_000,
+        "output_cost_per_token": 0.08 / 1_000_000,
+    },
+    "deepseek-r1-distill-llama-70b": {
+        "input_cost_per_token": 0.75 / 1_000_000,
+        "output_cost_per_token": 0.99 / 1_000_000,
+    },
+    # Cerebras
+    "llama-3.3-70b": {
+        "input_cost_per_token": 0.85 / 1_000_000,
+        "output_cost_per_token": 1.20 / 1_000_000,
+    },
+    "llama-3.1-8b": {
+        "input_cost_per_token": 0.10 / 1_000_000,
+        "output_cost_per_token": 0.10 / 1_000_000,
+    },
+    "qwen-3-32b": {
+        "input_cost_per_token": 0.45 / 1_000_000,
+        "output_cost_per_token": 0.65 / 1_000_000,
+    },
 }
 
 

--- a/src/llm/apply_agent.py
+++ b/src/llm/apply_agent.py
@@ -72,6 +72,30 @@ class ApplyAgent:
                 model=self.model,
                 base_url="https://openrouter.ai/api/v1",
             )
+        elif model_type == "nvidia_nim":
+            if not self.api_key:
+                raise ValueError("API key is required for NVIDIA NIM model")
+            llm = ChatOpenAI(
+                api_key=self.api_key,
+                model=self.model,
+                base_url="https://integrate.api.nvidia.com/v1",
+            )
+        elif model_type == "groq":
+            if not self.api_key:
+                raise ValueError("API key is required for Groq model")
+            llm = ChatOpenAI(
+                api_key=self.api_key,
+                model=self.model,
+                base_url="https://api.groq.com/openai/v1",
+            )
+        elif model_type == "cerebras":
+            if not self.api_key:
+                raise ValueError("API key is required for Cerebras model")
+            llm = ChatOpenAI(
+                api_key=self.api_key,
+                model=self.model,
+                base_url="https://api.cerebras.ai/v1",
+            )
         else:
             raise ValueError(f"Unsupported model type: {model_type}")
         return llm

--- a/src/llm/llm_manager.py
+++ b/src/llm/llm_manager.py
@@ -175,6 +175,81 @@ class OpenRouterModel(AIModel):
         return response
 
 
+class NvidiaNimModel(AIModel):
+    """Get access to models via NVIDIA NIM API (OpenAI-compatible endpoint)"""
+
+    def __init__(self, api_key: str, llm_model: str, llm_proxy: str = None) -> None:
+        from langchain_openai import ChatOpenAI
+
+        http_client = httpx.Client(proxy=llm_proxy) if llm_proxy else None
+        self.llm_proxy = llm_proxy
+        self.model_name = llm_model
+        self.model = ChatOpenAI(
+            model_name=self.model_name,
+            openai_api_key=api_key,
+            openai_api_base="https://integrate.api.nvidia.com/v1",
+            http_client=http_client,
+            temperature=TEMPERATURE,
+            timeout=120,
+        )
+
+    def invoke(self, prompt: ChatPromptTemplate) -> BaseMessage:
+        logger.info("Got access to model via NVIDIA NIM API")
+        prompt_messages = [SystemMessage(content=prompts.custom_instructions)] + prompt.messages
+        response = self.model.invoke(prompt_messages)
+        return response
+
+
+class GroqModel(AIModel):
+    """Get access to models via Groq API (OpenAI-compatible endpoint)"""
+
+    def __init__(self, api_key: str, llm_model: str, llm_proxy: str = None) -> None:
+        from langchain_openai import ChatOpenAI
+
+        http_client = httpx.Client(proxy=llm_proxy) if llm_proxy else None
+        self.llm_proxy = llm_proxy
+        self.model_name = llm_model
+        self.model = ChatOpenAI(
+            model_name=self.model_name,
+            openai_api_key=api_key,
+            openai_api_base="https://api.groq.com/openai/v1",
+            http_client=http_client,
+            temperature=TEMPERATURE,
+            timeout=60,
+        )
+
+    def invoke(self, prompt: ChatPromptTemplate) -> BaseMessage:
+        logger.info("Got access to model via Groq API")
+        prompt_messages = [SystemMessage(content=prompts.custom_instructions)] + prompt.messages
+        response = self.model.invoke(prompt_messages)
+        return response
+
+
+class CerebrasModel(AIModel):
+    """Get access to models via Cerebras API (OpenAI-compatible endpoint)"""
+
+    def __init__(self, api_key: str, llm_model: str, llm_proxy: str = None) -> None:
+        from langchain_openai import ChatOpenAI
+
+        http_client = httpx.Client(proxy=llm_proxy) if llm_proxy else None
+        self.llm_proxy = llm_proxy
+        self.model_name = llm_model
+        self.model = ChatOpenAI(
+            model_name=self.model_name,
+            openai_api_key=api_key,
+            openai_api_base="https://api.cerebras.ai/v1",
+            http_client=http_client,
+            temperature=TEMPERATURE,
+            timeout=60,
+        )
+
+    def invoke(self, prompt: ChatPromptTemplate) -> BaseMessage:
+        logger.info("Got access to model via Cerebras API")
+        prompt_messages = [SystemMessage(content=prompts.custom_instructions)] + prompt.messages
+        response = self.model.invoke(prompt_messages)
+        return response
+
+
 # class xAIModel(AIModel):
 #     """Get access to xAI model"""
 
@@ -236,6 +311,18 @@ class AIAdapter:
             return OllamaModel(self.easy_apply_model, llm_api_url)
         elif self.model_type == "openrouter":
             return OpenRouterModel(api_key, self.easy_apply_model, llm_proxy)
+        elif self.model_type == "nvidia_nim":
+            if not api_key:
+                raise ValueError("API key is required for NVIDIA NIM model")
+            return NvidiaNimModel(api_key, self.easy_apply_model, llm_proxy)
+        elif self.model_type == "groq":
+            if not api_key:
+                raise ValueError("API key is required for Groq model")
+            return GroqModel(api_key, self.easy_apply_model, llm_proxy)
+        elif self.model_type == "cerebras":
+            if not api_key:
+                raise ValueError("API key is required for Cerebras model")
+            return CerebrasModel(api_key, self.easy_apply_model, llm_proxy)
         # elif self.model_type == "xai":
         #     return xAIModel(api_key, self.easy_apply_model)
         # elif self.model_type == "huggingface":


### PR DESCRIPTION
## Summary

This PR adds support for three new OpenAI-compatible LLM providers, expanding the range of model backends users can choose from.

## New Providers

| Provider | Config value (`LLM_MODEL_TYPE`) | API Base URL |
|---|---|---|
| NVIDIA NIM | `nvidia_nim` | `https://integrate.api.nvidia.com/v1` |
| Groq | `groq` | `https://api.groq.com/openai/v1` |
| Cerebras | `cerebras` | `https://api.cerebras.ai/v1` |

## Changes

- **`src/llm/llm_manager.py`** — Added `NvidiaNimModel`, `GroqModel`, and `CerebrasModel` classes following the existing provider pattern (all use `ChatOpenAI` with custom `openai_api_base`). Added routing in `AIAdapter._create_model()`.
- **`src/llm/apply_agent.py`** — Added the same three provider branches in `ApplyAgent.select_model_type()` so the browser-use agent path also supports them.
- **`config/constants.py`** — Added representative token pricing entries to `PRICE_DICT` for popular models on each provider (falls back gracefully to `CUSTOM_COST_PER_TOKEN` for unlisted models).
- **`config/app_config.py`** — Updated `LLM_MODEL_TYPE` docstring with all new provider options and example model names per provider.

## Usage

Set in `config/app_config.py`:

```python
# Example: Groq
LLM_MODEL_TYPE = "groq"
EASY_APPLY_MODEL = "llama-3.3-70b-versatile"
APPLY_AGENT_MODEL = "llama-3.3-70b-versatile"
```

Then set your provider's API key in `.env` as `llm_api_key`.

## Testing

- All 53 existing `test_llm_manager.py` tests pass.
- Full test suite: 767 passed (1 pre-existing failure unrelated to this change).
- All modified files verified with `ast.parse()`.
```